### PR TITLE
Size and viewbox change in order to match vtex-apps/dreamstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Size and viewbox to 16 and '0 0 16 16'.
 
 ## [0.3.0] - 2018-11-21
 ### Added

--- a/react/Icon.js
+++ b/react/Icon.js
@@ -18,8 +18,8 @@ const Icon = ({ id, isActive, size, viewBox, activeClassName, muttedClassName, .
 
 Icon.defaultProps = {
   isActive: true,
-  size: '20',
-  viewBox: '0 0 20 20',
+  size: '16',
+  viewBox: '0 0 16 16',
   activeClassName: 'mid-gray',
   muttedClassName: 'light-gray',
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
As title says.

#### What problem is this solving?
Simplify the icon usage on vtex-apps/dreamstore

#### How should this be manually tested?
Run start script with npm/yarn

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.